### PR TITLE
Image index for Jenkins docker image builds.

### DIFF
--- a/deployment/image-index.yaml
+++ b/deployment/image-index.yaml
@@ -1,0 +1,4 @@
+images:
+  - name: geohosting
+    dockerfile: deployment/docker/Dockerfile
+    buildPath: .


### PR DESCRIPTION
Added the image-index.yaml file to the deployments directory. This file is needed by Jenkins to identify the Dockerfile from which to build the images for deployment from. May you please review the addition. Thank you 