### PR TITLE
patch: prevent invalid credentials error

### DIFF
--- a/django_project/geohosting/src/redux/reducers/supportSlice.ts
+++ b/django_project/geohosting/src/redux/reducers/supportSlice.ts
@@ -97,11 +97,13 @@ export const uploadAttachments = createAsyncThunk(
   'support/uploadAttachments',
   async ({ ticketId, files }: { ticketId: number; files: File[] }, thunkAPI) => {
     const formData = new FormData();
+    const token = localStorage.getItem('token');
     files.forEach(file => formData.append('attachments', file));
 
     try {
       const response = await axios.post(`/api/support/tickets/${ticketId}/attachments/`, formData, {
         headers: {
+          'Authorization': `Token ${token}`,
           'Content-Type': 'multipart/form-data'
         }
       });


### PR DESCRIPTION
![error](https://github.com/user-attachments/assets/cc26716d-8fd0-4598-aaa0-23e970951d15)

When creating a ticket , the upload attachments is failing because it requires authentication , so attaching a token to the request resolves that