### PR TITLE
Fix dignature canvas

### DIFF
--- a/django_project/geohosting/src/pages/CheckoutPage/CheckoutPage/Agreement.tsx
+++ b/django_project/geohosting/src/pages/CheckoutPage/CheckoutPage/Agreement.tsx
@@ -133,8 +133,6 @@ const SignaturePad = ({ onChange }) => {
         penColor="black"
         onEnd={handleSignatureEnd}
         canvasProps={{
-          width: 300,
-          height: 100,
           className: "border rounded-lg shadow-md",
         }}
       />


### PR DESCRIPTION
This is PR for https://github.com/kartoza/GeoHosting/issues/540

The issue was caused by canvas getting stretched due to the long client address. What I did is removing the size arguments when calling Signature Component..

https://github.com/user-attachments/assets/b9242ad2-23ef-4c02-827e-7caf49ca31de

https://github.com/user-attachments/assets/371327b1-9a2c-48fe-91eb-f0402a35ba56



