### PR TITLE
Change description

### DIFF
--- a/django_project/geohosting/src/components/ProductSupportGrid/ProductSupportGrid.tsx
+++ b/django_project/geohosting/src/components/ProductSupportGrid/ProductSupportGrid.tsx
@@ -103,7 +103,7 @@ const ProductSupportGrid = ({ product }) => {
     >
       <Card
         icon={FaGithub}
-        title="Download"
+        title="View Source Code"
         description={"The source code of " + product.name + " is freely available on GitHub"}
         buttonText="GitHub"
         descriptionMb="10"


### PR DESCRIPTION
Change the github source code description from "Download" to "View Source Code".

<img width="1259" height="337" alt="image" src="https://github.com/user-attachments/assets/c5613f02-f597-43d4-af4a-fe98ffbb9cce" />
<img width="1188" height="373" alt="image" src="https://github.com/user-attachments/assets/0b6506e6-3cd6-40a5-a0a4-bed2b15c1c0a" />

